### PR TITLE
:bug: Fixed display message when instances are empty

### DIFF
--- a/cli/cmd/instances/instances.go
+++ b/cli/cmd/instances/instances.go
@@ -34,6 +34,11 @@ var InstancesCmd = &cobra.Command{
 			return
 		}
 
+		if len(instances) < 1 {
+			fmt.Println("You currently have no instances.")
+			return
+		}
+
 		for _, instance := range instances {
 			fmt.Println(instance.String())
 		}


### PR DESCRIPTION
Fixed display message when instances are empty

Closes #63 